### PR TITLE
Add test-coverage workflow to fix the coverage badge

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -82,6 +82,16 @@ jobs:
         run: |
           mkdir -p coverage-report-site
           mv coverage-report.html coverage-report-site/index.html
+          # covr::report() -> htmltools::save_html() emits a sibling `lib/`
+          # directory (jQuery, DataTables, Bootstrap, ...) that index.html
+          # references with relative paths. It must ship alongside the report,
+          # or the deployed page renders unstyled and non-interactive.
+          if [ -d lib ]; then
+            mv lib coverage-report-site/lib
+          else
+            echo "::error::Expected covr report asset directory 'lib/' was not found"
+            exit 1
+          fi
         shell: bash
 
       - name: Deploy HTML coverage report to gh-pages (latest-tag)

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -27,6 +27,7 @@ concurrency:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   test-coverage:
@@ -46,7 +47,6 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::covr, any::DT, any::htmltools, any::xml2
-          needs: coverage
 
       - name: Run coverage
         run: |
@@ -67,6 +67,12 @@ jobs:
         shell: bash
 
       - name: Publish coverage badge and XML to _xml_coverage_reports
+        # Runs on push to main and on same-repo PRs. Skipped for fork PRs,
+        # whose GITHUB_TOKEN is read-only and cannot push the storage branch
+        # or post the PR comment (both would 403 and fail the job).
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: insightsengineering/coverage-action@v3
         with:
           path: ./coverage.xml

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,0 +1,94 @@
+# Test coverage workflow.
+#
+# Runs covr on pushes to and pull requests against main, then:
+#   * publishes the coverage badge and Cobertura XML to the orphan
+#     `_xml_coverage_reports` branch via insightsengineering/coverage-action
+#     (this is the source of the "Code Coverage" badge in README.md), and
+#   * deploys the HTML coverage report to the pkgdown site under
+#     `latest-tag/coverage-report/` (the badge's link target).
+#
+# The covr steps are derived from
+# https://github.com/r-lib/actions/tree/v2/examples ; the badge/report
+# publishing follows the openpharma coverage convention.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+name: test-coverage
+
+# Serialize gh-pages writes with the pkgdown workflow (which shares this group)
+# so the two deploy actions never push the gh-pages branch concurrently.
+concurrency:
+  group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  test-coverage:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::covr, any::DT, any::htmltools, any::xml2
+          needs: coverage
+
+      - name: Run coverage
+        run: |
+          cov <- covr::package_coverage(
+            quiet = FALSE,
+            clean = FALSE,
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
+          )
+          print(cov)
+          covr::to_cobertura(cov, filename = "coverage.xml")
+          covr::report(cov, file = "coverage-report.html", browse = FALSE)
+        shell: Rscript {0}
+
+      - name: Show testthat output
+        if: always()
+        run: |
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+
+      - name: Publish coverage badge and XML to _xml_coverage_reports
+        uses: insightsengineering/coverage-action@v3
+        with:
+          path: ./coverage.xml
+          threshold: 0
+          fail: false
+          publish: true
+          diff: true
+          diff-branch: main
+          coverage-summary-title: "Code Coverage Summary"
+
+      - name: Stage HTML report for deployment
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p coverage-report-site
+          mv coverage-report.html coverage-report-site/index.html
+        shell: bash
+
+      - name: Deploy HTML coverage report to gh-pages (latest-tag)
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        with:
+          clean: false
+          branch: gh-pages
+          folder: coverage-report-site
+          target-folder: latest-tag/coverage-report


### PR DESCRIPTION
### Changes Description

Fixes the broken **Code Coverage** badge on the README and pkgdown site.

**Root cause.** The badge markup points at coverage infrastructure that never existed:

- image → `https://raw.githubusercontent.com/openpharma/graphicalMCP/_xml_coverage_reports/data/main/badge.svg` — **404** (no `_xml_coverage_reports` branch)
- link → `https://openpharma.github.io/graphicalMCP/latest-tag/coverage-report/` — **404** (no report deployed)

The badge was added *commented out* at the openpharma transfer (`dcc2703`, Nov 2024) precisely because there was no coverage pipeline; the `gsd` branch un-commented it, so PR #98 made a broken badge visible on the site. There is no covr/coverage workflow anywhere in the repo's history.

**Fix.** Add a lightweight `test-coverage.yaml` (based on the r-lib/actions coverage example, matching this repo's existing `setup-r` + `setup-r-dependencies` setup — not the heavier insightsengineering shared pipeline) that, on pushes to and PRs against `main`:

1. runs `covr::package_coverage()` and writes Cobertura XML + an HTML report;
2. publishes `badge.svg` and `coverage.xml` to the orphan `_xml_coverage_reports` branch via `insightsengineering/coverage-action@v3` — this is the exact `data/<branch>/badge.svg` path the badge references, so the badge image starts resolving after the first run on `main`;
3. deploys the HTML report to `gh-pages` under `latest-tag/coverage-report/` — the badge's link target.

No README change is needed: the existing badge URLs are already correct for this convention; they simply had no producer.

**Notes for the reviewer**

- **No external service or secret.** The badge lives on the `_xml_coverage_reports` branch (pushed with the built-in `GITHUB_TOKEN`), not Codecov — so nothing to configure.
- **gh-pages safety.** `pkgdown.yaml` deploys with `clean: false`, so the `latest-tag/coverage-report/` subfolder survives pkgdown runs. The coverage workflow reuses pkgdown's existing concurrency group (`pkgdown-…`), so the two gh-pages deploys never push concurrently. `pkgdown.yaml` is left untouched.
- **Validated locally** on `main` (covr 3.6.4): **95.87%** line coverage; Cobertura XML and HTML report both generate cleanly in ~72s.
- **First-run behaviour.** The `_xml_coverage_reports` branch and the badge are created on the first run of this workflow on `main` (i.e. once this PR merges). The badge may show as broken for the couple of minutes until that run completes.
- **Fork PRs.** The badge-push step needs a write-scoped token, so it will not publish from pull requests opened from forks (same-repo branches are unaffected). `fail: false` keeps coverage non-blocking regardless.

### Task List

- [x] Coverage workflow added and YAML validated
- [x] covr run validated locally (95.87%)
- [x] No secrets / external services required
- [x] gh-pages deploys serialized; `latest-tag/coverage-report/` persists across pkgdown runs
