### PR TITLE
Update lrstat comparison test for the lrstat 0.3.3 fadjp* API

### DIFF
--- a/tests/testthat/test-graph_test_closure.R
+++ b/tests/testthat/test-graph_test_closure.R
@@ -278,50 +278,58 @@ test_that("compare adjusted p-values to lrstat - Bonferroni & Simes", {
 
   p <- pnorm(rnorm(6, 2.5), lower.tail = FALSE)
 
-  if (requireNamespace("lrstat", quietly = TRUE)) {
-    fwgtmat_will_run <- tryCatch(
-      {
-        lrstat::fwgtmat(g$hypotheses, g$transitions)
-        TRUE
-      },
-      error = function(cond) FALSE
+  # lrstat 0.3.3 reworked the fadjp* interface: the raw p-values are now the
+  # first argument, the graph weights are supplied as the fwgtmat() list
+  # (`inthyp` + `wgtmat`) rather than as separate `w`/`G` (Bonferroni) or a
+  # bare weight matrix (Simes), and the functions return a list whose `$padj`
+  # holds the adjusted elementary-hypothesis p-values. Require >= 0.3.3 so the
+  # comparison targets the current interface; on older lrstat the test skips.
+  skip_if_not_installed("lrstat", "0.3.3")
+
+  fwgtmat_will_run <- tryCatch(
+    {
+      lrstat::fwgtmat(g$hypotheses, g$transitions)
+      TRUE
+    },
+    error = function(cond) FALSE
+  )
+
+  if (fwgtmat_will_run) {
+    # fwgtmat() now returns list(inthyp, wgtmat); pass it straight through as
+    # the `wgtmat` argument to both fadjpbon() and fadjpsim().
+    gw <- lrstat::fwgtmat(g$hypotheses, g$transitions)
+
+    fam1 <- matrix(1, ncol = 6)
+    fam2 <- rbind(c(1, 1, 1, 0, 0, 0), c(0, 0, 0, 1, 1, 1))
+
+    expect_equal(
+      graph_test_shortcut(g, p)$outputs$adjusted_p,
+      lrstat::fadjpbon(p, gw)$padj,
+      ignore_attr = TRUE
     )
 
-    if (fwgtmat_will_run) {
-      gw <- lrstat::fwgtmat(g$hypotheses, g$transitions)
+    expect_equal(
+      graph_test_closure(g, p)$outputs$adjusted_p,
+      lrstat::fadjpbon(p, gw)$padj,
+      ignore_attr = TRUE
+    )
 
-      fam1 <- matrix(1, ncol = 6)
-      fam2 <- rbind(c(1, 1, 1, 0, 0, 0), c(0, 0, 0, 1, 1, 1))
+    expect_equal(
+      graph_test_closure(g, p, test_types = "s")$outputs$adjusted_p,
+      lrstat::fadjpsim(p, gw, fam1)$padj,
+      ignore_attr = TRUE
+    )
 
-      expect_equal(
-        graph_test_shortcut(g, p)$outputs$adjusted_p,
-        lrstat::fadjpbon(g$hypotheses, g$transitions, matrix(p, ncol = 6)),
-        ignore_attr = TRUE
-      )
-
-      expect_equal(
-        graph_test_closure(g, p)$outputs$adjusted_p,
-        lrstat::fadjpbon(g$hypotheses, g$transitions, matrix(p, ncol = 6)),
-        ignore_attr = TRUE
-      )
-
-      expect_equal(
-        graph_test_closure(g, p, test_types = "s")$outputs$adjusted_p,
-        lrstat::fadjpsim(gw, p, fam1),
-        ignore_attr = TRUE
-      )
-
-      expect_equal(
-        graph_test_closure(
-          g,
-          p,
-          test_groups = list(1:3, 4:6),
-          test_types = "s"
-        )$outputs$adjusted_p,
-        lrstat::fadjpsim(gw, p, fam2),
-        ignore_attr = TRUE
-      )
-    }
+    expect_equal(
+      graph_test_closure(
+        g,
+        p,
+        test_groups = list(1:3, 4:6),
+        test_types = "s"
+      )$outputs$adjusted_p,
+      lrstat::fadjpsim(p, gw, fam2)$padj,
+      ignore_attr = TRUE
+    )
   }
 })
 


### PR DESCRIPTION
## Why

Kaifeng Lu (lrstat maintainer) reported a **reverse-dependency failure**: submitting `lrstat 0.3.3` to CRAN breaks graphicalMCP's unit tests that call `fadjpbon()` / `fadjpsim()`, because 0.3.3 changed the interface of those functions.

## What changed in lrstat 0.3.3 (verified against upstream source)

- `p` (raw p-values) is now the **first** argument.
- The graph weight structure is supplied as a single `wgtmat` **list** (`inthyp` + `wgtmat`), i.e. the output of `fwgtmat(w, G)` — which itself now returns that list instead of a bare weight matrix.
- The functions now **return a list** (`inthyp`, `pinter`, `padj`); the adjusted elementary-hypothesis p-values are in `$padj` (a length-`m` vector for a single p-vector).

| old (≤ 0.3.2) | new (≥ 0.3.3) |
|---|---|
| `fadjpbon(w, G, p)` | `fadjpbon(p, fwgtmat(w, G))$padj` |
| `fadjpsim(wgtmat, p, family)` | `fadjpsim(p, wgtmat, family)$padj` |

## The fix

`tests/testthat/test-graph_test_closure.R` — the *only* build-included call site (`misc/` and the `comparisons`/`generate-closure` vignettes are in `.Rbuildignore`, so CRAN does not run them):

- Migrated the calls to the 0.3.3 interface. graphicalMCP builds its own weights via `fwgtmat()`, so it passes that list straight through — no `finthyp()` needed.
- Guarded the block with `skip_if_not_installed("lrstat", "0.3.3")` so it **skips on the CRAN-current 0.3.2** (this package stays green today) and **runs the new interface on ≥ 0.3.3** (lrstat's reverse-dep check passes).

## Why DESCRIPTION is *not* pinned to `lrstat (>= 0.3.3)` yet

`lrstat 0.3.3` is not on CRAN yet (CRAN has 0.3.2). Pinning `Suggests: lrstat (>= 0.3.3)` now would make `pak` / `setup-r-dependencies` unable to resolve it and **break this package's own CI and CRAN checks**. The runtime skip-guard enforces the same version requirement without that side effect. Add the DESCRIPTION pin once lrstat 0.3.3 reaches CRAN.

## Verification

- Ran the test file locally with lrstat 0.3.0 installed: the block **skips** (`Installed lrstat is version 0.3.0; but 0.3.3 is required`); all other tests in the file pass.
- The 0.3.3 call shapes were verified against `kaifenglu/lrstat` source (`R/multiplicity.R`, `src/multiplicity.cpp`): `fadjpbon`/`fadjpsim` accept a vector `p`, take the `fwgtmat` list as `wgtmat`, and return `$padj` as a length-`m` vector — directly comparable to graphicalMCP's `adjusted_p`. The underlying closed Bonferroni/Simes computation is unchanged, so the numeric equality the test asserts is preserved.
- Could not execute against lrstat 0.3.3 locally (no CRAN/R-universe binary for R 4.4; source build blocked by an unrelated host C++ toolchain issue). CI (with CRAN lrstat 0.3.2) exercises the skip path; the new-API path will be exercised by lrstat's own reverse-dep check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)