### PR TITLE
Fix pkgdown build: migrate comparisons vignette to lrstat 0.3.3 fadjpsim API

### DIFF
--- a/vignettes/comparisons.Rmd
+++ b/vignettes/comparisons.Rmd
@@ -217,10 +217,10 @@ for (i in 1:10000) {
   names(graphicalmcp_test_simes) <- NULL
   lrstat_test_simes <-
     fadjpsim(
-      fwgtmat(graph$hypotheses, graph$transitions),
       p,
+      fwgtmat(graph$hypotheses, graph$transitions),
       family
-    )
+    )$padj
 
   identical <- c(
     identical,


### PR DESCRIPTION
## Problem

After PR #101 merged, the **pkgdown** workflow on `main` failed while rendering `vignettes/comparisons.Rmd` (the `[simes]` chunk):

```
! Not compatible with requested type: [type=list; target=double].
 1. └─lrstat::fadjpsim(...)
```

`R-CMD-check` and `test-coverage` passed — only the docs-site build broke.

## Cause

`lrstat 0.3.3` is now on CRAN. It reworked `fadjpsim()`: `p` is the first argument, the graph weights are passed as the `fwgtmat()` list, and the adjusted p-values are returned in `$padj`. The comparison **test** was migrated in #101, but `comparisons.Rmd` still used the old `fadjpsim(weights, p, family)` convention. The vignette is in `.Rbuildignore`, so `R CMD check`/CRAN never exercised it, but pkgdown renders it and its CI now installs lrstat 0.3.3.

## Fix

Migrate the single `fadjpsim()` call to the 0.3.3 interface, matching the already-migrated `tests/testthat/test-graph_test_closure.R`:

```r
fadjpsim(p, fwgtmat(graph$hypotheses, graph$transitions), family)$padj
```

## Verification

Ran the corrected chunk against local lrstat 0.3.3 over 200 random graphs — adjusted p-values match `graphicalMCP::graph_test_closure()` for all cases (max abs diff **4.3e-11**). The repo's other built vignette, `generate-closure.Rmd`, only calls `fwgtmat()` inside `bench::mark(check = FALSE)` with the result unused, and `fwgtmat`'s inputs are unchanged, so it is unaffected.

Note: this does not affect CRAN-submittability of 0.3.0 (the vignette isn't in the build). The pkgdown check on this PR is the end-to-end confirmation.