### PR TITLE
Fix oversized nodes in group-sequential-testing case-study plot

### DIFF
--- a/vignettes/group-sequential-testing.Rmd
+++ b/vignettes/group-sequential-testing.Rmd
@@ -195,7 +195,7 @@ g <- graph_create(hypotheses, transitions)
 ```
 
 ```{r graph-plot, eval = requireNamespace("igraph", quietly = TRUE)}
-plot(g, vertex.size = 60)
+plot(g, vertex.size = 40)
 ```
 
 ### Observed P-values


### PR DESCRIPTION
## Problem

In the group sequential testing vignette, the section **"Case Study using repeated p-values and look_back = FALSE"** plots the four-hypothesis graph with `plot(g, vertex.size = 60)`. At the default figure size (7×5 in), the nodes are too large and are clipped against the top and bottom of the plotting area; the edge arrowheads are also hidden beneath the oversized nodes.

## Fix

Reduce the node size to `vertex.size = 40`. All four nodes then fit fully within the plotting area and the arrowheads are visible. Only this plot is changed — the oncology case-study plot (which uses a custom layout and `asp`) is untouched.

## Verification

Rendered the chunk at the vignette's figure dimensions (7×5 in, dpi 192) at both sizes:
- `vertex.size = 60`: H1–H4 clipped top and bottom.
- `vertex.size = 40`: nodes fully inside the area, arrowheads visible.