### PR TITLE
Expand README acknowledgments; drop stray LazyData field

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,6 @@ VignetteBuilder:
     knitr
 Config/testthat/edition: 3
 Encoding: UTF-8
-LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
 Language: en-US

--- a/README.Rmd
+++ b/README.Rmd
@@ -75,6 +75,6 @@ Built upon these packages, we hope to implement graphical MCPs in a more general
 
 Along with the authors and contributors, thanks to the following people for their suggestions and inspirations on the package:
 
-Frank Bretz, Willi Maurer, Ekkehard Glimm, Nan Chen, Jeremy Wildfire, Spencer Childress, Colleen McLaughlin, Matt Roumaya, Chelsea Dickens, Nan Xiao, Keaven Anderson, and Ron Yu
+Keaven Anderson, Frank Bretz, Nan Chen, Yao Chen, Spencer Childress, Chelsea Dickens, Ekkehard Glimm, Willi Maurer, Colleen McLaughlin, Friedrich Pahlke, Matt Roumaya, Daniel Sabanés Bové, Alex Spiers, Gernot Wassmer, Jeremy Wildfire, Nan Xiao, Yanyao Yi, Ron Yu, and Ying Zhang
 
 We owe a debt of gratitude to the authors of [gMCP](https://cran.r-project.org/package=gMCP) for their pioneering work, without which this package would not be nearly as extensive as it is.

--- a/README.md
+++ b/README.md
@@ -88,9 +88,10 @@ without losing computational efficiency.
 Along with the authors and contributors, thanks to the following people
 for their suggestions and inspirations on the package:
 
-Frank Bretz, Willi Maurer, Ekkehard Glimm, Nan Chen, Jeremy Wildfire,
-Spencer Childress, Colleen McLaughlin, Matt Roumaya, Chelsea Dickens,
-Nan Xiao, Keaven Anderson, and Ron Yu
+Keaven Anderson, Frank Bretz, Nan Chen, Yao Chen, Spencer Childress,
+Chelsea Dickens, Ekkehard Glimm, Willi Maurer, Colleen McLaughlin,
+Friedrich Pahlke, Matt Roumaya, Daniel Sabanés Bové, Alex Spiers, Gernot
+Wassmer, Jeremy Wildfire, Nan Xiao, Yanyao Yi, Ron Yu, and Ying Zhang
 
 We owe a debt of gratitude to the authors of
 [gMCP](https://cran.r-project.org/package=gMCP) for their pioneering


### PR DESCRIPTION
Two small pre-release tidy-ups. No functional code changes.

## README acknowledgments

Added seven names to the acknowledgments list and sorted the **entire** list alphabetically by last name (updated both `README.Rmd` and the generated `README.md`):

New: Yao Chen, Friedrich Pahlke, Daniel Sabanés Bové, Alex Spiers, Gernot Wassmer, Yanyao Yi, Ying Zhang.

Final order: Anderson, Bretz, Chen (Nan), Chen (Yao), Childress, Dickens, Glimm, Maurer, McLaughlin, Pahlke, Roumaya, Sabanés Bové, Spiers, Wassmer, Wildfire, Xiao, Yi, Yu, Zhang.

`README.md` was edited to match the exact wrap `devtools::build_readme()` produces, so only the acknowledgment paragraph changes (no unrelated reformatting churn).

## DESCRIPTION

Removed `LazyData: true`. The package has no `data/` directory, so `R CMD build` was already stripping the field (the harmless `Omitted 'LazyData' from DESCRIPTION` build message). No effect on the built tarball or checks.