### PR TITLE
Fix CRAN NOTE: reduce print.power_report example runtime

### DIFF
--- a/R/print.power_report.R
+++ b/R/print.power_report.R
@@ -55,11 +55,12 @@
 #' )
 #' set.seed(1234)
 #' # Bonferroni tests
+#' # Reduce the number of simulations to save time for package compilation
 #' power_output <- graph_calculate_power(
 #'   g,
 #'   alpha,
 #'   sim_corr = corr,
-#'   sim_n = 1e5,
+#'   sim_n = 1e2,
 #'   power_marginal = marginal_power,
 #'   sim_success = success_fns
 #' )

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,14 +1,20 @@
 # Version 0.3.0
 
-- This is the tenth submission to CRAN.
+- This is the tenth submission to CRAN. This is a resubmission: the previous
+  submission's incoming check flagged one NOTE for the `print.power_report`
+  example running longer than 10 seconds. The number of simulations in that
+  example has been reduced (matching the `graph_calculate_power` example), so it
+  now runs in a fraction of a second.
 - This release adds group sequential testing for graphical multiple comparison
   procedures via `graph_test_shortcut_gsd()`, with spending functions and the
   supporting functions `gs_boundaries()`, `gs_corr()`, `repeated_p()`, and
   `sequential_p()`, plus two new vignettes (including validation against the
   gsDesign and rpact packages).
-- A Suggests-only test comparing adjusted p-values against the lrstat package
-  was updated for the lrstat 0.3.3 interface (coordinated with its maintainer);
-  it runs only when lrstat (>= 0.3.3) is installed.
+- The check errors currently shown for the released version (0.2.9) come from a
+  Suggests-only unit test comparing adjusted p-values against the lrstat
+  package, which broke when lrstat 0.3.3 changed its `fadjp*` interface. This
+  release updates that test for the lrstat 0.3.3 interface (coordinated with its
+  maintainer); it runs only when lrstat (>= 0.3.3) is installed.
 
 ## R CMD check results
 

--- a/man/print.power_report.Rd
+++ b/man/print.power_report.Rd
@@ -58,11 +58,12 @@ success_fns <- list(
 )
 set.seed(1234)
 # Bonferroni tests
+# Reduce the number of simulations to save time for package compilation
 power_output <- graph_calculate_power(
   g,
   alpha,
   sim_corr = corr,
-  sim_n = 1e5,
+  sim_n = 1e2,
   power_marginal = marginal_power,
   sim_success = success_fns
 )


### PR DESCRIPTION
## Why

The 0.3.0 submission was held at CRAN's incoming pretest with **1 NOTE** (Windows):

```
* checking examples ... [23s] NOTE
Examples with CPU (user + system) or elapsed time > 10s
                    user system elapsed
print.power_report 11.83      0   11.82
```

The `print.power_report` example ran `graph_calculate_power()` with `sim_n = 1e5` (~11.8s), over CRAN's 10s example limit. (The near-identical `graph_calculate_power` example already uses `sim_n = 1e2`.)

## Fix

- Reduce the example's `sim_n` to `1e2`, matching the sibling example, and regenerate the `.Rd`. It now runs in **~0.03s**.
- Update `cran-comments.md`: note the resubmission, and explain that the 3 ERRORs shown for the released **0.2.9** are the lrstat 0.3.3 reverse-dependency failures (`fadjpbon(...)`: *unused argument*) that this 0.3.0 release resolves.

## Note on the "ERROR: 3" in the CRAN email

That line refers to the **currently-published 0.2.9**, not this submission — its `test-graph_test_closure.R` uses the old lrstat API and breaks against lrstat 0.3.3 (now on CRAN). 0.3.0 already fixes this (merged in #101). This PR only addresses the example-timing NOTE that held 0.3.0 itself.