### PR TITLE
Add Michael Grayling to README acknowledgments

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -75,6 +75,6 @@ Built upon these packages, we hope to implement graphical MCPs in a more general
 
 Along with the authors and contributors, thanks to the following people for their suggestions and inspirations on the package:
 
-Keaven Anderson, Frank Bretz, Nan Chen, Yao Chen, Spencer Childress, Chelsea Dickens, Ekkehard Glimm, Willi Maurer, Colleen McLaughlin, Friedrich Pahlke, Matt Roumaya, Daniel Sabanés Bové, Alex Spiers, Gernot Wassmer, Jeremy Wildfire, Nan Xiao, Yanyao Yi, Ron Yu, and Ying Zhang
+Keaven Anderson, Frank Bretz, Nan Chen, Yao Chen, Spencer Childress, Chelsea Dickens, Ekkehard Glimm, Michael Grayling, Willi Maurer, Colleen McLaughlin, Friedrich Pahlke, Matt Roumaya, Daniel Sabanés Bové, Alex Spiers, Gernot Wassmer, Jeremy Wildfire, Nan Xiao, Yanyao Yi, Ron Yu, and Ying Zhang
 
 We owe a debt of gratitude to the authors of [gMCP](https://cran.r-project.org/package=gMCP) for their pioneering work, without which this package would not be nearly as extensive as it is.

--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ Along with the authors and contributors, thanks to the following people
 for their suggestions and inspirations on the package:
 
 Keaven Anderson, Frank Bretz, Nan Chen, Yao Chen, Spencer Childress,
-Chelsea Dickens, Ekkehard Glimm, Willi Maurer, Colleen McLaughlin,
-Friedrich Pahlke, Matt Roumaya, Daniel Sabanés Bové, Alex Spiers, Gernot
-Wassmer, Jeremy Wildfire, Nan Xiao, Yanyao Yi, Ron Yu, and Ying Zhang
+Chelsea Dickens, Ekkehard Glimm, Michael Grayling, Willi Maurer, Colleen
+McLaughlin, Friedrich Pahlke, Matt Roumaya, Daniel Sabanés Bové, Alex
+Spiers, Gernot Wassmer, Jeremy Wildfire, Nan Xiao, Yanyao Yi, Ron Yu,
+and Ying Zhang
 
 We owe a debt of gratitude to the authors of
 [gMCP](https://cran.r-project.org/package=gMCP) for their pioneering


### PR DESCRIPTION
Adds Michael Grayling to the README acknowledgments list, inserted in alphabetical order by last name (between Glimm and Maurer). Updated both `README.Rmd` and the generated `README.md` (re-wrapped to match `build_readme()` output; only the acknowledgment paragraph changes).