### PR TITLE
Bump to development version 0.3.0.9000

### DIFF
--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,3 +1,3 @@
-Version: 0.2.9
-Date: 2025-05-07 03:10:43 UTC
-SHA: 86213d2cf7bf8a29ac608260f2fd935e7fc2fd7d
+Version: 0.3.0
+Date: 2026-08-27 01:29:41 UTC
+SHA: bc8730f1625ab7251db8c9f85bb1e14b8e65c8a7

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: graphicalMCP
 Title: Graphical Multiple Comparison Procedures
-Version: 0.3.0
+Version: 0.3.0.9000
 Authors@R: c(
     person("Dong", "Xi", , "dong.xi1@gilead.com", role = c("aut", "cre")),
     person("Ethan", "Brockmann", , "ethan.brockmann@atorusresearch.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -74,3 +74,5 @@
 * Renamed the `Adj. P-value` column to `Adj.p` in `print.graph_report()`
 * Added a warning in `graph_create()` for very small transition weights (Issue #97)
 * Plotting examples, vignettes, and tests are skipped when `igraph` or `gMCP` is not installed
+
+# graphicalMCP (development version)


### PR DESCRIPTION
Post-release housekeeping now that 0.3.0 is on CRAN and tagged (v0.3.0).

- `DESCRIPTION`: `Version: 0.3.0` → `0.3.0.9000`.
- `NEWS.md`: add a `# graphicalMCP (development version)` heading for ongoing changes (appended at the end, matching this file's oldest-first ordering).